### PR TITLE
Adding double quotes for Org and Space name in Endorsement Text

### DIFF
--- a/postal/strategies/organization_strategy.go
+++ b/postal/strategies/organization_strategy.go
@@ -7,8 +7,8 @@ import (
 	"github.com/cloudfoundry-incubator/notifications/postal/utilities"
 )
 
-const OrganizationEndorsement = "You received this message because you belong to the {{.Organization}} organization."
-const OrganizationRoleEndorsement = "You received this message because you are an {{.OrganizationRole}} in the {{.Organization}} organization."
+const OrganizationEndorsement = "You received this message because you belong to the \"{{.Organization}}\" organization."
+const OrganizationRoleEndorsement = "You received this message because you are an {{.OrganizationRole}} in the \"{{.Organization}}\" organization."
 
 type OrganizationStrategy struct {
 	tokenLoader        postal.TokenLoaderInterface

--- a/postal/strategies/space_strategy.go
+++ b/postal/strategies/space_strategy.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudfoundry-incubator/notifications/postal/utilities"
 )
 
-const SpaceEndorsement = "You received this message because you belong to the {{.Space}} space in the {{.Organization}} organization."
+const SpaceEndorsement = "You received this message because you belong to the \"{{.Space}}\" space in the \"{{.Organization}}\" organization."
 
 type SpaceStrategy struct {
 	tokenLoader        postal.TokenLoaderInterface


### PR DESCRIPTION
This pull request solves the problem stated in https://www.pivotaltracker.com/n/projects/1107230/stories/88648948