### PR TITLE
Manifest specifies Go buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,3 +3,4 @@ applications:
   - name: notifications
     command: bin/notifications
     memory: 64M
+    buildpack: go_buildpack


### PR DESCRIPTION
- this speeds up deployment, since the stager only needs to download the 1 buildpack, not all of them

- are there environments where the go buildpack has a non-standard name?  in that case, this could cause a problem.

@ryanmoran I can't recall if there was a reason we didn't set this before....